### PR TITLE
Init Classic API support with Computer Groups

### DIFF
--- a/buildings.go
+++ b/buildings.go
@@ -2,7 +2,7 @@ package jamf
 
 import "fmt"
 
-const uriBuildings = "/v1/buildings"
+const uriBuildings = "/uapi/v1/buildings"
 
 type ResponseBuildings struct {
 	TotalCount *int       `json:"totalCount,omitempty"`
@@ -34,10 +34,10 @@ func (c *Client) GetBuildingIdByName(name string) (string, error) {
 			break
 		}
 	}
-	return id, nil
+	return id, err
 }
 
-func (c *Client) GetBuildingByName(name string) (data *Building, err error) {
+func (c *Client) GetBuildingByName(name string) (*Building, error) {
 	id, err := c.GetBuildingIdByName(name)
 	if err != nil {
 		return nil, err
@@ -46,21 +46,19 @@ func (c *Client) GetBuildingByName(name string) (data *Building, err error) {
 	return c.GetBuilding(id)
 }
 
-func (c *Client) GetBuilding(id string) (data *Building, err error) {
+func (c *Client) GetBuilding(id string) (*Building, error) {
 	var out *Building
 	uri := fmt.Sprintf("%s/%s", uriBuildings, id)
+	err := c.doRequest("GET", uri, nil, &out)
 
-	err = c.doRequest("GET", uri, nil, &out)
-	data = out
-	return
+	return out, err
 }
 
-func (c *Client) GetBuildings() (data *ResponseBuildings, err error) {
+func (c *Client) GetBuildings() (*ResponseBuildings, error) {
 	out := &ResponseBuildings{}
-	err = c.doRequest("GET", uriBuildings, nil, &out)
-	data = out
+	err := c.doRequest("GET", uriBuildings, nil, &out)
 
-	return
+	return out, err
 }
 
 func (c *Client) CreateBuilding(name, sa1, sa2, city, sp, zpc, country *string) (*Building, error) {
@@ -84,10 +82,8 @@ func (c *Client) CreateBuilding(name, sa1, sa2, city, sp, zpc, country *string) 
 
 	var out *Building
 
-	if err := c.doRequest("POST", uriBuildings, in, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
+	err := c.doRequest("POST", uriBuildings, in, &out)
+	return out, err
 }
 
 func (c *Client) UpdateBuilding(d *Building) (*Building, error) {
@@ -112,10 +108,8 @@ func (c *Client) UpdateBuilding(d *Building) (*Building, error) {
 		Country:        d.Country,
 	}
 
-	if err := c.doRequest("PUT", uri, in, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
+	err := c.doRequest("PUT", uri, in, &out)
+	return out, err
 }
 
 func (c *Client) DeleteBuilding(name string) error {

--- a/categories.go
+++ b/categories.go
@@ -2,7 +2,7 @@ package jamf
 
 import "fmt"
 
-const uriCategories = "/v1/categories"
+const uriCategories = "/uapi/v1/categories"
 
 type ResponseCategories struct {
 	TotalCount *int       `json:"totalCount,omitempty"`
@@ -29,10 +29,10 @@ func (c *Client) GetCategoryIdByName(name string) (string, error) {
 			break
 		}
 	}
-	return id, nil
+	return id, err
 }
 
-func (c *Client) GetCategoryByName(name string) (data *Category, err error) {
+func (c *Client) GetCategoryByName(name string) (*Category, error) {
 	id, err := c.GetCategoryIdByName(name)
 	if err != nil {
 		return nil, err
@@ -41,20 +41,18 @@ func (c *Client) GetCategoryByName(name string) (data *Category, err error) {
 	return c.GetCategory(id)
 }
 
-func (c *Client) GetCategory(id string) (data *Category, err error) {
+func (c *Client) GetCategory(id string) (*Category, error) {
 	var out *Category
 	uri := fmt.Sprintf("%s/%s", uriCategories, id)
 
-	err = c.doRequest("GET", uri, nil, &out)
-	data = out
-	return
+	err := c.doRequest("GET", uri, nil, &out)
+	return out, err
 }
 
-func (c *Client) GetCategories() (data *ResponseCategories, err error) {
+func (c *Client) GetCategories() (*ResponseCategories, error) {
 	var out *ResponseCategories
-	err = c.doRequest("GET", uriCategories, nil, &out)
-	data = out
-	return
+	err := c.doRequest("GET", uriCategories, nil, &out)
+	return out, err
 }
 
 func (c *Client) CreateCategory(name *string, priority *int) (*Category, error) {
@@ -68,10 +66,8 @@ func (c *Client) CreateCategory(name *string, priority *int) (*Category, error) 
 
 	var out *Category
 
-	if err := c.doRequest("POST", uriCategories, in, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
+	err := c.doRequest("POST", uriCategories, in, &out)
+	return out, err
 }
 
 func (c *Client) UpdateCategory(d *Category) (*Category, error) {
@@ -86,10 +82,8 @@ func (c *Client) UpdateCategory(d *Category) (*Category, error) {
 		Priority: d.Priority,
 	}
 
-	if err := c.doRequest("PUT", uri, in, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
+	err := c.doRequest("PUT", uri, in, &out)
+	return out, err
 }
 
 func (c *Client) DeleteCategory(name string) error {

--- a/client.go
+++ b/client.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	uriAuthToken = "/auth/tokens"
+	uriAuthToken = "/uapi/auth/tokens"
 )
 
 // Client ... stores an object to talk with Jamf API
@@ -47,10 +47,6 @@ func NewClient(username, password, url string) (*Client, error) {
 	}
 
 	c.token = out.Token
-
-	// initialize what don't need
-	c.username = ""
-	c.password = ""
 
 	return c, nil
 }

--- a/computerGroups.go
+++ b/computerGroups.go
@@ -5,7 +5,7 @@ import "fmt"
 const uriComputerGroups = "/JSSResource/computergroups"
 
 type ComputerGroupsResponse struct {
-	Count   int                         `xml:"size"`
+	Size    int                         `xml:"size"`
 	Results []ComputerGroupListResponse `xml:"computer_group"`
 }
 
@@ -16,14 +16,14 @@ type ComputerGroupListResponse struct {
 }
 
 type ComputerGroup struct {
-	ID            int                      `xml:"id"`
-	Name          string                   `xml:"name"`
-	IsSmart       bool                     `xml:"is_smart"`
-	Site          Site                     `xml:"site"`
-	Criteria      []ComputerGroupCriterion `xml:"criteria>criterion"`
-	CriteriaCount int                      `xml:"criteria>size"`
-	Computers     []Computer               `xml:"computers>computer"`
-	ComputerCount int                      `xml:"computers>size"`
+	ID           int                      `xml:"id"`
+	Name         string                   `xml:"name"`
+	IsSmart      bool                     `xml:"is_smart"`
+	Site         Site                     `xml:"site"`
+	Criteria     []ComputerGroupCriterion `xml:"criteria>criterion"`
+	CriteriaSize int                      `xml:"criteria>size"`
+	Computers    []Computer               `xml:"computers>computer"`
+	ComputerSize int                      `xml:"computers>size"`
 }
 
 type ComputerGroupRequest struct {

--- a/computerGroups.go
+++ b/computerGroups.go
@@ -1,0 +1,122 @@
+package jamf
+
+import "fmt"
+
+const uriComputerGroups = "/JSSResource/computergroups"
+
+type ComputerGroupsResponse struct {
+	Count   int                         `xml:"size"`
+	Results []ComputerGroupListResponse `xml:"computer_group"`
+}
+
+type ComputerGroupListResponse struct {
+	ID      int    `xml:"id,omitempty"`
+	Name    string `xml:"name,omitempty"`
+	IsSmart bool   `xml:"is_smart,omitempty"`
+}
+
+type ComputerGroup struct {
+	ID            int                      `xml:"id"`
+	Name          string                   `xml:"name"`
+	IsSmart       bool                     `xml:"is_smart"`
+	Site          Site                     `xml:"site"`
+	Criteria      []ComputerGroupCriterion `xml:"criteria>criterion"`
+	CriteriaCount int                      `xml:"criteria>size"`
+	Computers     []ComputerGroupResp      `xml:"computers>computer"`
+	ComputerCount int                      `xml:"computers>size"`
+}
+
+type ComputerGroupRequest struct {
+	Name      string                      `xml:"name"`
+	IsSmart   bool                        `xml:"is_smart"`
+	Site      Site                        `xml:"site"`
+	Criteria  []ComputerGroupCriterion    `xml:"criteria>criterion"`
+	Computers []ComputerGroupListResponse `xml:"computers>computer,omitempty"`
+}
+
+type ComputerGroupCriterion struct {
+	Name         string             `xml:"name"`
+	Priority     int                `xml:"priority"`
+	AndOr        ComputerGroupAndOr `xml:"and_or"`
+	SearchType   string             `xml:"search_type"`
+	SearchValue  string             `xml:"value"`
+	OpeningParen bool               `xml:"opening_paren"`
+	ClosingParen bool               `xml:"closing_paren"`
+}
+
+type ComputerGroupAndOr string
+
+const (
+	And ComputerGroupAndOr = "and"
+	Or  ComputerGroupAndOr = "or"
+)
+
+func (c *Client) GetComputerGroupIdByName(name string) (int, error) {
+	var id int
+	d, err := c.GetComputerGroups()
+	if err != nil {
+		return -1, err
+	}
+
+	for _, v := range d.Results {
+		if v.Name == name {
+			id = v.ID
+			break
+		}
+	}
+	return id, err
+}
+
+func (c *Client) GetComputerGroupByName(name string) (data *ComputerGroup, err error) {
+	id, err := c.GetComputerGroupIdByName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetComputerGroup(id)
+}
+
+func (c *Client) GetComputerGroup(id int) (data *ComputerGroup, err error) {
+	var out *ComputerGroup
+	uri := fmt.Sprintf("%s/id/%v", uriComputerGroups, id)
+	err = c.doRequest("GET", uri, nil, &out)
+
+	return out, err
+}
+
+func (c *Client) GetComputerGroups() (data *ComputerGroupsResponse, err error) {
+	out := &ComputerGroupsResponse{}
+	err = c.doRequest("GET", uriComputerGroups, nil, &out)
+
+	return out, err
+}
+
+func (c *Client) CreateComputerGroup(computerGroupRequest *ComputerGroupRequest) error {
+
+	reqBody := &struct {
+		*ComputerGroupRequest
+		XMLName struct{} `xml:"computer_group"`
+	}{
+		ComputerGroupRequest: computerGroupRequest,
+	}
+
+	return c.doRequest("POST", fmt.Sprintf("%s/id/0", uriComputerGroups), reqBody, &struct{}{})
+}
+
+func (c *Client) UpdateComputerGroup(d *ComputerGroup) error {
+	uri := fmt.Sprintf("%s/id/%v", uriComputerGroups, d.ID)
+
+	reqBody := &struct {
+		*ComputerGroup
+		XMLName struct{} `xml:"computer_group"`
+	}{
+		ComputerGroup: d,
+	}
+
+	return c.doRequest("PUT", uri, reqBody, &struct{}{})
+}
+
+func (c *Client) DeleteComputerGroup(id int) error {
+	uri := fmt.Sprintf("%s/id/%v", uriComputerGroups, id)
+	return c.doRequest("DELETE", uri, nil, &struct{}{})
+}

--- a/computerGroups.go
+++ b/computerGroups.go
@@ -22,7 +22,7 @@ type ComputerGroup struct {
 	Site          Site                     `xml:"site"`
 	Criteria      []ComputerGroupCriterion `xml:"criteria>criterion"`
 	CriteriaCount int                      `xml:"criteria>size"`
-	Computers     []ComputerGroupResp      `xml:"computers>computer"`
+	Computers     []Computer               `xml:"computers>computer"`
 	ComputerCount int                      `xml:"computers>size"`
 }
 
@@ -67,7 +67,7 @@ func (c *Client) GetComputerGroupIdByName(name string) (int, error) {
 	return id, err
 }
 
-func (c *Client) GetComputerGroupByName(name string) (data *ComputerGroup, err error) {
+func (c *Client) GetComputerGroupByName(name string) (*ComputerGroup, error) {
 	id, err := c.GetComputerGroupIdByName(name)
 	if err != nil {
 		return nil, err
@@ -76,23 +76,24 @@ func (c *Client) GetComputerGroupByName(name string) (data *ComputerGroup, err e
 	return c.GetComputerGroup(id)
 }
 
-func (c *Client) GetComputerGroup(id int) (data *ComputerGroup, err error) {
+func (c *Client) GetComputerGroup(id int) (*ComputerGroup, error) {
 	var out *ComputerGroup
 	uri := fmt.Sprintf("%s/id/%v", uriComputerGroups, id)
-	err = c.doRequest("GET", uri, nil, &out)
+	err := c.doRequest("GET", uri, nil, &out)
 
 	return out, err
 }
 
-func (c *Client) GetComputerGroups() (data *ComputerGroupsResponse, err error) {
+func (c *Client) GetComputerGroups() (*ComputerGroupsResponse, error) {
 	out := &ComputerGroupsResponse{}
-	err = c.doRequest("GET", uriComputerGroups, nil, &out)
+	err := c.doRequest("GET", uriComputerGroups, nil, out)
 
 	return out, err
 }
 
-func (c *Client) CreateComputerGroup(computerGroupRequest *ComputerGroupRequest) error {
+func (c *Client) CreateComputerGroup(computerGroupRequest *ComputerGroupRequest) (int, error) {
 
+	group := &ComputerGroup{}
 	reqBody := &struct {
 		*ComputerGroupRequest
 		XMLName struct{} `xml:"computer_group"`
@@ -100,12 +101,14 @@ func (c *Client) CreateComputerGroup(computerGroupRequest *ComputerGroupRequest)
 		ComputerGroupRequest: computerGroupRequest,
 	}
 
-	return c.doRequest("POST", fmt.Sprintf("%s/id/0", uriComputerGroups), reqBody, &struct{}{})
+	err := c.doRequest("POST", fmt.Sprintf("%s/id/0", uriComputerGroups), reqBody, group)
+	return group.ID, err
 }
 
-func (c *Client) UpdateComputerGroup(d *ComputerGroup) error {
-	uri := fmt.Sprintf("%s/id/%v", uriComputerGroups, d.ID)
+func (c *Client) UpdateComputerGroup(d *ComputerGroup) (int, error) {
 
+	group := &ComputerGroup{}
+	uri := fmt.Sprintf("%s/id/%v", uriComputerGroups, d.ID)
 	reqBody := &struct {
 		*ComputerGroup
 		XMLName struct{} `xml:"computer_group"`
@@ -113,10 +116,16 @@ func (c *Client) UpdateComputerGroup(d *ComputerGroup) error {
 		ComputerGroup: d,
 	}
 
-	return c.doRequest("PUT", uri, reqBody, &struct{}{})
+	err := c.doRequest("PUT", uri, reqBody, group)
+
+	return group.ID, err
 }
 
-func (c *Client) DeleteComputerGroup(id int) error {
+func (c *Client) DeleteComputerGroup(id int) (int, error) {
+
+	group := &ComputerGroup{}
 	uri := fmt.Sprintf("%s/id/%v", uriComputerGroups, id)
-	return c.doRequest("DELETE", uri, nil, &struct{}{})
+	err := c.doRequest("DELETE", uri, nil, group)
+
+	return group.ID, err
 }

--- a/computerGroups.go
+++ b/computerGroups.go
@@ -27,11 +27,11 @@ type ComputerGroup struct {
 }
 
 type ComputerGroupRequest struct {
-	Name      string                      `xml:"name"`
-	IsSmart   bool                        `xml:"is_smart"`
-	Site      Site                        `xml:"site"`
-	Criteria  []ComputerGroupCriterion    `xml:"criteria>criterion"`
-	Computers []ComputerGroupListResponse `xml:"computers>computer,omitempty"`
+	Name      string                   `xml:"name"`
+	IsSmart   bool                     `xml:"is_smart"`
+	Site      Site                     `xml:"site"`
+	Criteria  []ComputerGroupCriterion `xml:"criteria>criterion"`
+	Computers []Computer               `xml:"computers>computer,omitempty"`
 }
 
 type ComputerGroupCriterion struct {

--- a/computers.go
+++ b/computers.go
@@ -1,7 +1,7 @@
 package jamf
 
 type Computer struct {
-	ID           int    `json:"id,omitempty" xml:"id"`
-	Name         string `json:"name,omitempty" xml:"name"`
-	SerialNumber string `json:"serial_number,omitempty" xml:"serial_number"`
+	ID           int    `json:"id,omitempty" xml:"id,omitempty"`
+	Name         string `json:"name,omitempty" xml:"name,omitempty"`
+	SerialNumber string `json:"serial_number,omitempty" xml:"serial_number,omitempty"`
 }

--- a/computers.go
+++ b/computers.go
@@ -1,0 +1,7 @@
+package jamf
+
+type ComputerGroupResp struct {
+	ID           int    `json:"id,omitempty" xml:"id"`
+	Name         string `json:"name,omitempty" xml:"name"`
+	SerialNumber string `json:"serial_number,omitempty" xml:"serial_number"`
+}

--- a/computers.go
+++ b/computers.go
@@ -1,6 +1,6 @@
 package jamf
 
-type ComputerGroupResp struct {
+type Computer struct {
 	ID           int    `json:"id,omitempty" xml:"id"`
 	Name         string `json:"name,omitempty" xml:"name"`
 	SerialNumber string `json:"serial_number,omitempty" xml:"serial_number"`

--- a/departments.go
+++ b/departments.go
@@ -2,7 +2,7 @@ package jamf
 
 import "fmt"
 
-const uriDepartments = "/v1/departments"
+const uriDepartments = "/uapi/v1/departments"
 
 type ResponseDepartments struct {
 	TotalCount *int         `json:"totalCount,omitempty"`
@@ -28,10 +28,10 @@ func (c *Client) GetDepartmentIdByName(name string) (string, error) {
 			break
 		}
 	}
-	return id, nil
+	return id, err
 }
 
-func (c *Client) GetDepartmentByName(name string) (data *Department, err error) {
+func (c *Client) GetDepartmentByName(name string) (*Department, error) {
 	id, err := c.GetDepartmentIdByName(name)
 	if err != nil {
 		return nil, err
@@ -40,20 +40,18 @@ func (c *Client) GetDepartmentByName(name string) (data *Department, err error) 
 	return c.GetDepartment(id)
 }
 
-func (c *Client) GetDepartment(id string) (data *Department, err error) {
+func (c *Client) GetDepartment(id string) (*Department, error) {
 	var out *Department
 	uri := fmt.Sprintf("%s/%s", uriDepartments, id)
 
-	err = c.doRequest("GET", uri, nil, &out)
-	data = out
-	return
+	err := c.doRequest("GET", uri, nil, &out)
+	return out, err
 }
 
-func (c *Client) GetDepartments() (data *ResponseDepartments, err error) {
+func (c *Client) GetDepartments() (*ResponseDepartments, error) {
 	var out *ResponseDepartments
-	err = c.doRequest("GET", uriDepartments, nil, &out)
-	data = out
-	return
+	err := c.doRequest("GET", uriDepartments, nil, &out)
+	return out, err
 }
 
 func (c *Client) CreateDepartment(name *string) (*Department, error) {
@@ -65,10 +63,8 @@ func (c *Client) CreateDepartment(name *string) (*Department, error) {
 
 	var out *Department
 
-	if err := c.doRequest("POST", uriDepartments, in, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
+	err := c.doRequest("POST", uriDepartments, in, &out)
+	return out, err
 }
 
 func (c *Client) UpdateDepartment(d *Department) (*Department, error) {
@@ -81,10 +77,8 @@ func (c *Client) UpdateDepartment(d *Department) (*Department, error) {
 		Name: d.Name,
 	}
 
-	if err := c.doRequest("PUT", uri, in, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
+	err := c.doRequest("PUT", uri, in, &out)
+	return out, err
 }
 
 func (c *Client) DeleteDepartment(name string) error {

--- a/request.go
+++ b/request.go
@@ -44,7 +44,7 @@ func (c *Client) doRequest(method, api string, reqbody, out interface{}) error {
 		}
 		re := regexp.MustCompile(`\r?\n`)
 		out := re.ReplaceAllString(string(body), " ")
-		return fmt.Errorf("api error %s: %s", resp.Status, out)
+		return fmt.Errorf("API Error: %s, URI: %s, Body: %s", resp.Status, api, out)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/sites.go
+++ b/sites.go
@@ -1,0 +1,6 @@
+package jamf
+
+type Site struct {
+	ID   int    `json:"id,omitempty" xml:"id,omitempty"`
+	Name string `json:"name,omitempty" xml:"name,omitempty"`
+}


### PR DESCRIPTION
Created support for the Classic API with XML request bodies with computer groups, both smart and static supported. 

Also did some cleanup of your code to make it easier to read for anyone in the future. Would love to discuss the usage of unnecessary pointers...